### PR TITLE
Fix deprecation errors

### DIFF
--- a/Block/Search/Result.php
+++ b/Block/Search/Result.php
@@ -207,7 +207,7 @@ class Result extends \Magento\Framework\View\Element\Template
         ->setOrder('position','ASC');
         $this->setCollection($brandCollection);
 
-        $searchKey = $this->_request->getParam('s');
+        $searchKey = $this->_request->getParam('s') ?? '';
 
         $brandCollection->addFieldToFilter(['name', 'description', 'url_key'], [
                                     ['like'=>'%'.addslashes($searchKey).'%'],

--- a/Controller/Search/Result.php
+++ b/Controller/Search/Result.php
@@ -94,7 +94,7 @@ class Result extends \Magento\Framework\App\Action\Action
         $page = $this->resultPageFactory->create();
         $brandHelper = $this->_brandHelper;
         $request = $this->getRequest();
-        if(!$brandHelper->getConfig('general_settings/enable') || !trim($this->_request->getParam('s'))){
+        if(!$brandHelper->getConfig('general_settings/enable') || !trim($this->_request->getParam('s') ?? '')){
             $resultForward = $this->resultForwardFactory->create();
             return $resultForward->forward('defaultnoroute');
         }


### PR DESCRIPTION
In PHP > 8, passing null to `trim()` and `addslashes()` will result in a deprecated functionality exception being thrown. To prevent this, I added a default value of an empty string to the parameter `s`.