### PR TITLE
Patch Reflected XSS

### DIFF
--- a/view/frontend/templates/search/form.phtml
+++ b/view/frontend/templates/search/form.phtml
@@ -7,7 +7,7 @@ $helper = $this->helper("Ves\Brand\Helper\Data");
 	</div>
 	<div class="block-content">
 		<form method="get" class="search-form" action="<?php echo $helper->getSearchFormUrl(); ?>" data-mage-init='{"validation":{}}'>
-			<input type="text" class="search-field required-entry" placeholder="<?php echo __('Search brands here…'); ?>" value="<?php echo $helper->getSearchKey() ?>" name="s" title="<?php echo __('Search for:'); ?>">
+			<input type="text" class="search-field required-entry" placeholder="<?php echo __('Search brands here…'); ?>" value="<?php echo $block->escapeHtmlAttr($helper->getSearchKey()) ?>" name="s" title="<?php echo __('Search for:'); ?>">
 			<button type="submit" class="search-submit"><i class="fa fa-search"></i></button>
 		</form>
 	</div>


### PR DESCRIPTION
`getSearchKey()` pulls straight from a user supplied GET parameter (i.e., `s`) from [Helper/Data](https://github.com/landofcoder/module-brand/blob/master/Helper/Data.php#L173C19-L173C19) with no sanitization nor escaping. This causes reflected XSS such as `https://<domain>/vesbrand/search/result?s=bob"><audio src=x onerror=alert(1)><!--`, which will result in an alert popping up.